### PR TITLE
update: rename `versions` to `releases` / fix `https_proxy` env var

### DIFF
--- a/sapo/cli/cli.py
+++ b/sapo/cli/cli.py
@@ -66,12 +66,12 @@ def install(
 
 
 @app.command()
-def versions(
+def releases(
     limit: int = typer.Option(
         10, "--limit", "-l", help="Number of versions to show (default: 10)"
     ),
 ) -> None:
-    """List available Artifactory versions with size and timestamp information.
+    """List available Artifactory releases with size and timestamp information.
 
     Fetches and displays a list of available Artifactory versions,
     including file sizes and release dates.

--- a/sapo/cli/http.py
+++ b/sapo/cli/http.py
@@ -1,0 +1,42 @@
+"""HTTP client utilities."""
+
+import os
+from rich.console import Console
+import aiohttp
+
+console = Console()
+
+
+def debug_print(msg: str, debug: bool = False) -> None:
+    """Print debug message if debug mode is enabled."""
+    if debug:
+        console.print(f"DEBUG: {msg}")
+
+
+def create_client_session(debug: bool = False) -> aiohttp.ClientSession:
+    """Create an aiohttp client session with proxy support if needed.
+
+    This function respects HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables
+    to configure the aiohttp client session with proxy support.
+
+    Args:
+        debug: Whether to print debug information
+
+    Returns:
+        aiohttp.ClientSession: A configured client session with trust_env=True,
+            which enables proxy support based on environment variables
+    """
+    # Get proxy settings from environment variables (just for debug output)
+    https_proxy = os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
+    http_proxy = os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy")
+    no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+
+    if https_proxy or http_proxy:
+        debug_print(f"Using proxies - HTTP: {http_proxy}, HTTPS: {https_proxy}", debug)
+        if no_proxy:
+            debug_print(f"NO_PROXY: {no_proxy}", debug)
+    else:
+        debug_print("No proxies configured", debug)
+
+    # Create ClientSession with trust_env=True to respect proxy environment variables
+    return aiohttp.ClientSession(trust_env=True)

--- a/sapo/cli/release_notes.py
+++ b/sapo/cli/release_notes.py
@@ -11,6 +11,8 @@ from rich.table import Table
 from rich.text import Text
 import aiohttp
 
+from sapo.cli.http import create_client_session
+
 console = Console()
 
 # Base URL and map ID for JFrog's help system
@@ -139,7 +141,8 @@ async def get_release_notes(
 ) -> Optional[Dict[str, Any]]:
     """Get release notes for a specific version."""
     try:
-        async with aiohttp.ClientSession() as session:
+        # Create a client session with proxy support
+        async with create_client_session(debug) as session:
             # First, get the map info to find the topics endpoint
             map_info = await get_map_info(session, debug)
             if not map_info:
@@ -192,7 +195,8 @@ async def list_available_versions(debug: bool = False) -> List[str]:
         url = "https://jfrog.com/help/r/jfrog-release-information/artifactory-self-hosted-releases"
         debug_print(f"Loading versions index: {url}", debug)
 
-        async with aiohttp.ClientSession() as session:
+        # Create a client session with proxy support
+        async with create_client_session(debug) as session:
             async with session.get(url) as response:
                 if response.status != 200:
                     debug_print("Failed to load versions index", debug)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,9 +20,9 @@ def test_install_command(mock_install):
 
 
 @patch("sapo.cli.cli.list_versions")
-def test_versions_command(mock_list_versions):
-    """Test the versions command."""
-    result = runner.invoke(app, ["versions", "--limit", "5"])
+def test_releases_command(mock_list_versions):
+    """Test the releases command."""
+    result = runner.invoke(app, ["releases", "--limit", "5"])
     assert result.exit_code == 0
     mock_list_versions.assert_called_once_with(limit=5)
 

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -1,0 +1,56 @@
+"""Tests for ClientSession creation with proxy support."""
+
+import os
+from unittest.mock import patch
+from sapo.cli.http import create_client_session
+
+
+def test_create_client_session_with_trust_env():
+    """Test that create_client_session creates a ClientSession with trust_env=True."""
+    with patch("sapo.cli.http.aiohttp.ClientSession") as mock_session:
+        # Call the function
+        create_client_session()
+
+        # Verify trust_env=True was used
+        mock_session.assert_called_once_with(trust_env=True)
+
+
+def test_create_client_session_respects_http_proxy():
+    """Test that HTTP_PROXY environment variable is respected."""
+    with patch.dict(
+        os.environ, {"HTTP_PROXY": "http://proxy.example.com:8080"}, clear=True
+    ):
+        with patch("sapo.cli.http.aiohttp.ClientSession") as mock_session:
+            # Call the function
+            create_client_session(debug=True)
+
+            # Verify trust_env=True was used
+            mock_session.assert_called_once_with(trust_env=True)
+
+
+def test_create_client_session_respects_https_proxy():
+    """Test that HTTPS_PROXY environment variable is respected."""
+    with patch.dict(
+        os.environ, {"HTTPS_PROXY": "https://proxy.example.com:8443"}, clear=True
+    ):
+        with patch("sapo.cli.http.aiohttp.ClientSession") as mock_session:
+            # Call the function
+            create_client_session(debug=True)
+
+            # Verify trust_env=True was used
+            mock_session.assert_called_once_with(trust_env=True)
+
+
+def test_create_client_session_respects_no_proxy():
+    """Test that NO_PROXY environment variable is respected."""
+    env = {
+        "HTTP_PROXY": "http://proxy.example.com:8080",
+        "NO_PROXY": "localhost,127.0.0.1,.example.com",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        with patch("sapo.cli.http.aiohttp.ClientSession") as mock_session:
+            # Call the function
+            create_client_session(debug=True)
+
+            # Verify trust_env=True was used
+            mock_session.assert_called_once_with(trust_env=True)


### PR DESCRIPTION
Fix client high uses aiohttp  as its default does not recognize environment configs.

BREAKING CHANGE: move `versions` command to `releases`