### PR TITLE
fix: resolve remaining Bandit security warnings

### DIFF
--- a/sapo/cli/install_mode/docker.py
+++ b/sapo/cli/install_mode/docker.py
@@ -371,8 +371,7 @@ async def run_docker_compose(docker_compose_dir: Path, debug: bool = False) -> b
 
     try:
         # Execute docker compose up with live output
-        # nosec B603: Docker command is trusted and validated
-        process = subprocess.Popen(
+        process = subprocess.Popen(  # nosec B603
             cmd,
             cwd=docker_compose_dir,
             stdout=subprocess.PIPE,

--- a/sapo/cli/install_mode/docker/container.py
+++ b/sapo/cli/install_mode/docker/container.py
@@ -136,8 +136,7 @@ class DockerContainerManager:
         try:
             # Execute docker compose up
             cmd = ["docker", "compose", "up", "-d"]
-            # nosec B603: Docker command is trusted and validated
-            process = subprocess.Popen(
+            process = subprocess.Popen(  # nosec B603
                 cmd,
                 cwd=self.compose_dir,
                 stdout=subprocess.PIPE,

--- a/sapo/cli/install_mode/docker/volume.py
+++ b/sapo/cli/install_mode/docker/volume.py
@@ -843,7 +843,8 @@ class VolumeManager:
                         )
                     except Exception:
                         # Docker volume label is not supported in older Docker versions, so ignore errors
-                        pass
+                        # This is acceptable as label adding is optional metadata enhancement
+                        pass  # nosec B110
 
                 progress.update(
                     task,

--- a/sapo/cli/install_mode/templates/__init__.py
+++ b/sapo/cli/install_mode/templates/__init__.py
@@ -36,9 +36,8 @@ def render_template_from_file(
         module_path = template_path
 
     # Create Jinja environment
-    # nosec B701: Templates are for infrastructure config (YAML/shell), not HTML
     # Autoescape would break Docker Compose and shell script generation
-    env = Environment(
+    env = Environment(  # nosec B701
         loader=FileSystemLoader(module_path),
         trim_blocks=True,
         lstrip_blocks=True,


### PR DESCRIPTION
## Summary
Fixes the remaining 4 Bandit security issues identified in CI runs to achieve zero security warnings.

## Security Issues Fixed

### B603 (Low) - subprocess.Popen calls  
- **Location**: `sapo/cli/install_mode/docker.py:375`
- **Location**: `sapo/cli/install_mode/docker/container.py:140`
- **Fix**: Moved `# nosec B603` comments to the same line as the `subprocess.Popen` calls for proper suppression
- **Justification**: These are trusted Docker commands that have been validated

### B110 (Low) - try/except/pass block
- **Location**: `sapo/cli/install_mode/docker/volume.py:844`  
- **Fix**: Added `# nosec B110` with detailed justification
- **Justification**: This intentionally ignores Docker volume label errors for backward compatibility with older Docker versions. The operation is optional metadata enhancement.

### B701 (High) - Jinja2 autoescape=False
- **Location**: `sapo/cli/install_mode/templates/__init__.py:41`
- **Fix**: Moved `# nosec B701` comment to the same line as `Environment()` call
- **Justification**: Templates generate Docker Compose YAML and shell scripts, not HTML. Autoescape would break the generated configuration files.

## Test Results
- ✅ Local Bandit scan shows **0 issues** remaining
- ✅ All security suppressions are properly documented
- ✅ 9 total issues now suppressed with justification

## Impact
- Resolves all security warnings in CI pipeline
- Maintains secure coding practices with documented exceptions  
- No functional changes to application behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved container startup logs: stderr is now merged into stdout with real-time, line-by-line text output for clearer diagnostics.
- Refactor
  - Streamlined subprocess output handling to provide consistent, buffered text streams without altering overall behavior or exit handling.
- Chores
  - Standardized security annotations placement and removed redundant explanatory comments for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->